### PR TITLE
Omit last one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tigerdenversi"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "training program for ruversi."
 

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -717,7 +717,7 @@ impl BitBoard {
     }
 
     pub fn is_full(&self) -> bool {
-        (self.black | self.white) == 0xffffffffffffffff
+        (self.black | self.white) == u64::MAX
     }
 
     pub fn flip_all(&self) -> BitBoard {

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -724,6 +724,7 @@ impl BitBoard {
         (self.black | self.white).count_zeros() <= 1
     }
 
+    #[allow(dead_code)]
     pub fn is_last1(&self) -> bool {
         (self.black | self.white).count_zeros() == 1
     }

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -720,6 +720,14 @@ impl BitBoard {
         (self.black | self.white) == u64::MAX
     }
 
+    pub fn is_last1_or_full(&self) -> bool {
+        (self.black | self.white).count_zeros() <= 1
+    }
+
+    pub fn is_last1(&self) -> bool {
+        (self.black | self.white).count_zeros() == 1
+    }
+
     pub fn flip_all(&self) -> BitBoard {
         BitBoard {
             black : self.white,

--- a/src/data_loader.rs
+++ b/src/data_loader.rs
@@ -40,7 +40,12 @@ pub fn loadkifu(files : &[String], d : &str, progress : usize,
         let kifu = kifu::Kifu::from(&lines);
         kifu.list.par_iter().filter_map(|t| {
             let ban = bitboard::BitBoard::from(&t.rfen).unwrap();
-            if ban.is_full() || !ban.is_progress(progress) {return None;}
+            // 最後の局面とか覚えたい進行度の時じゃない
+            // if ban.is_full() || !ban.is_progress(progress) {return None;}
+            // 最後の局面とか後言っての局面とか覚えたい進行度の時じゃない
+            if ban.is_last1_or_full() || !ban.is_progress(progress) {
+                return None;
+            }
 
             let (fsb, fsw) = ban.fixedstones();
             let score = kifu.score.unwrap();


### PR DESCRIPTION
1升空きの局面を学習対象から外した。
最終結果と1対1対応が取れてNNを通す必要がないため。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * パッケージバージョンを 0.6.1 にアップデート

* **改善**
  * データ処理パイプラインの内部ロジックを最適化
  * 内部ユーティリティ機能を強化

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->